### PR TITLE
トップのボタンから直接招待URLに飛んでもらう

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -23,7 +23,7 @@ layout: layouts/base.njk
         </div>
       </div>
       <div>
-        <a href="#join" class="btn btn-discord-brand jumbotron-join-button btn-lg py-3 px-5 shadow">
+        <a href="https://discord.com/invite/8taubbJ5qD" class="btn btn-discord-brand jumbotron-join-button btn-lg py-3 px-5 shadow">
           Discord に参加する
         </a>
       </div>


### PR DESCRIPTION
- コミュニティポリシーは登録してから読むことになるのでよし
- Discord の説明については招待URLの画面にかかれているのでよし