### PR TITLE
CIとしてビルドを追加する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18.16.1' # Cloudflare Pages uses Node.js 18.16.1
+
+      - run: npm install
+
+      - run: npm run build


### PR DESCRIPTION
Renovate のPRはプレビュー環境を作らないようにしたので、ActionsでビルドするCIを追加します